### PR TITLE
Go import path fixes to build project locally

### DIFF
--- a/controller/web.go
+++ b/controller/web.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gocolly/colly"
-	"github.com/mikecrinite/craigslist-go/model"
+	"github.com/mikecrinite/craigslist-global/model"
 )
 
 var scheme = "https://"                        // Craiglist uses HTTPS protocol
@@ -142,7 +142,7 @@ func CleanForQuery(dirty string) string {
 }
 
 func stripTitleFromUrl(url string) string {
-	l := strings.Split(url, "/") 
+	l := strings.Split(url, "/")
 	if len(l) > 2 {
 		dirtyTitle := l[len(l) - 2]
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/mikecrinite/craiglist-global
-
 require (
 	github.com/PuerkitoBio/goquery v1.4.1 // indirect
 	github.com/andybalholm/cascadia v1.0.0 // indirect
@@ -20,3 +18,5 @@ require (
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+module github.com/mikecrinite/craigslist-global

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/mikecrinite/craigslist-go/controller"
-	"github.com/mikecrinite/craigslist-go/model"
+	"github.com/mikecrinite/craigslist-global/controller"
+	"github.com/mikecrinite/craigslist-global/model"
 
 	"github.com/gin-gonic/gin"
 )


### PR DESCRIPTION
Resolves errors while building locally:
```
build github.com/mikecrinite/craiglist-global: cannot find module for path github.com/mikecrinite/craigslist-go/controller
```

```
go: github.com/mikecrinite/craigslist-global@v0.0.0-20181003013117-049dfc8c8182: parsing go.mod: unexpected module path "github.com/mikecrinite/craiglist-global"
go: error loading module requirements
```

Signed-off-by: Kevin <kevin@stealsyour.pw>