### PR TITLE
Remove line break causing column alignment issues

### DIFF
--- a/web/templates/index.tmpl
+++ b/web/templates/index.tmpl
@@ -36,7 +36,6 @@
                     <span>{{ .Title }} - {{ .Price }}</span>
                 </a>
             </li>
-            <br/>
         {{ end }}
         </ul>
     </div>


### PR DESCRIPTION
Line break was causing columns to be uneven in alignment.

Short term fixes: https://github.com/mikecrinite/craigslist-global/issues/4

Signed-off-by: Kevin <kevin@stealsyour.pw>