### PR TITLE
Add region to post display

### DIFF
--- a/web/templates/index.tmpl
+++ b/web/templates/index.tmpl
@@ -38,7 +38,7 @@
                         background-image: url(/img/Craigslist-logotyp.jpg)
                         {{ end }}
                     " onclick="window.location = {{ .PostLink }}">
-                    <span class="outline">{{ .Title }} - {{ .Price }}</span>
+                    <span class="outline">{{ .Title }} - {{ .Price }} - {{ .Region }}</span>
                 </a>
             </li>
             <br/>


### PR DESCRIPTION
If not wanted, then feel free to reject. I figured adding the region to the post display would be beneficial. 

The word wrapping isn't terrible. It could probably be better. Maybe if I split the region to show on the bottom of the picture separate from the title? I'm not a CSS person haha. 

![Uploading Screen Shot 2018-10-09 at 16.57.34.png…]()

Signed-off-by: Kevin <kevin@stealsyour.pw>